### PR TITLE
21 branch

### DIFF
--- a/gitatom/__main__.py
+++ b/gitatom/__main__.py
@@ -18,7 +18,6 @@ import shutil
 
 def atomify(filename):
     print(f"calling atomify on {filename}")
-    print(config.options['publish_directory'])
     # atomify.py
     # Encloses given md in atom xml tags
 
@@ -41,14 +40,9 @@ def atomify(filename):
     if not filename.endswith('.md'): exit("Incorrect input file type (expected .md)")
     md = filename
 
-    # NOTE may not need this if using a separate file for feed tags...
-    config_f = open('gitatom/gitatom.config')
-    cfg = config_f.readlines()
-    config_f.close()
-
     # Populate required tags 
-    feed_id = cfg[0].strip()
-    feed_title = cfg[1].strip()
+    feed_id = config.options['feed_id']
+    feed_title = config.options['feed_title']
 
     entry_title = path.splitext(path.basename(md))[0] # TODO make os-agnostic 
     entry_id = feed_id + entry_title # depends on feed id

--- a/gitatom/__main__.py
+++ b/gitatom/__main__.py
@@ -114,7 +114,7 @@ def publish(filename):
     # the file. Example: aaa-bbb-ccc-file.html is copied to
     # ./site/posts/aaa/bbb/ccc/file.html
 
-    TARGET_DIRECTORY = "./site/posts/"
+    TARGET_DIRECTORY = config.options["publish_directory"]
     ERROR = -1
 
     src_path = Path(filename)

--- a/gitatom/__main__.py
+++ b/gitatom/__main__.py
@@ -1,4 +1,5 @@
 import build
+import config
 from sys import argv
 
 from os import path
@@ -17,6 +18,7 @@ import shutil
 
 def atomify(filename):
     print(f"calling atomify on {filename}")
+    print(config.options['publish_directory'])
     # atomify.py
     # Encloses given md in atom xml tags
 
@@ -41,12 +43,12 @@ def atomify(filename):
 
     # NOTE may not need this if using a separate file for feed tags...
     config_f = open('gitatom/gitatom.config')
-    config = config_f.readlines()
+    cfg = config_f.readlines()
     config_f.close()
 
     # Populate required tags 
-    feed_id = config[0].strip()
-    feed_title = config[1].strip()
+    feed_id = cfg[0].strip()
+    feed_title = cfg[1].strip()
 
     entry_title = path.splitext(path.basename(md))[0] # TODO make os-agnostic 
     entry_id = feed_id + entry_title # depends on feed id

--- a/gitatom/atomify.py
+++ b/gitatom/atomify.py
@@ -22,6 +22,7 @@ import glob
 import sys 
 import re
 import string
+import config
 
 # Generate blog post title from .md filename
 def getTitle(filename):
@@ -90,14 +91,9 @@ def atomify(md):
 	exists = glob.glob('./*' + outname[8:] + '*') # should only ever return 0-1 matches
 	if exists: outname = exists[0][2:] # overwrite existing file 
 
-	# Grab tags from config
-	config_f = open('gitatom.config')
-	config = config_f.readlines()
-	config_f.close()
-
 	# Populate tags
-	feed_id = config[0].strip()
-	feed_title = config[1].strip()
+        feed_id = config.options['feed_id']
+        feed_title = config.options['feed_title']
 	entry_id = feed_id + outname[:-4] 
 	if exists: # retain existing publish date
 		tree = ET.parse(outname) 

--- a/gitatom/config.py
+++ b/gitatom/config.py
@@ -1,5 +1,10 @@
 import yaml
 
+# Add "import config" to any file where you need to access config options.
+# Access the options using the names defined in config.yaml:
+#       ex.
+#           blog_title = config.options["feed_title"]
+
 options = {}
 
 def load():
@@ -8,4 +13,5 @@ def load():
     options = yaml.load(config_file, yaml.FullLoader)
     config_file.close()
 
+# this is called when config is imported
 load()

--- a/gitatom/config.py
+++ b/gitatom/config.py
@@ -1,0 +1,11 @@
+import yaml
+
+options = {}
+
+def load():
+    config_file = open("gitatom/config.yaml", "r")
+    global options
+    options = yaml.load(config_file, yaml.FullLoader)
+    config_file.close()
+
+load()

--- a/gitatom/config.yaml
+++ b/gitatom/config.yaml
@@ -1,0 +1,6 @@
+---
+feed_id: https://git.atom/
+feed_title: "Git Atom"
+author_name: "Josh M. Carlson"
+entry_template: gitatom/templates/blogs.html
+publish_directory: site/posts/

--- a/gitatom/config.yaml
+++ b/gitatom/config.yaml
@@ -1,6 +1,6 @@
 ---
 feed_id: https://git.atom/
 feed_title: Git Atom
-author_name: Josh M. Carlson
+author_name: Author
 entry_template: gitatom/templates/blogs.html
 publish_directory: site/posts/

--- a/gitatom/config.yaml
+++ b/gitatom/config.yaml
@@ -1,6 +1,6 @@
 ---
 feed_id: https://git.atom/
-feed_title: "Git Atom"
-author_name: "Josh M. Carlson"
+feed_title: Git Atom
+author_name: Josh M. Carlson
 entry_template: gitatom/templates/blogs.html
 publish_directory: site/posts/

--- a/gitatom/gitatom.config
+++ b/gitatom/gitatom.config
@@ -1,2 +1,0 @@
-https://git.atom/
-Git Atom

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 GitPython
 jinja2
 cmarkgfm
+pyyaml


### PR DESCRIPTION
Added the ability to access config options throughout the program.

To access options, first import config.py into the file you are accessing them from: "import config". To get the value of an option, reference the dictionary using the option's name: "blog_title = config.options["feed_title"]".

I changed all of the old code that uses the old config file to use the new method.

I replaced the old config file "gitatom.config" with "config.yaml". This file is a YAML file and consists of key/value pairs separated by a colon. This file can be easily edited to add more options and change existing options.

The python library "pyyaml" is used to load in the config file. I added that library to the list of dependencies in requirements.txt